### PR TITLE
Fix: compatibility with older metall versions

### DIFF
--- a/src/dice/ffi/metall.h
+++ b/src/dice/ffi/metall.h
@@ -4,7 +4,9 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+#if __has_include(<metall/logger_interface.h>)
 #include <metall/logger_interface.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/dice/ffi/metall.h
+++ b/src/dice/ffi/metall.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#if METALL_VERSION >= 2800
+#if __has_include(<metall/logger_interface.h>)
 #include <metall/logger_interface.h>
 #endif
 

--- a/src/dice/ffi/metall.h
+++ b/src/dice/ffi/metall.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#if __has_include(<metall/logger_interface.h>)
+#if METALL_VERSION >= 2800
 #include <metall/logger_interface.h>
 #endif
 

--- a/src/dice/ffi/metall.h
+++ b/src/dice/ffi/metall.h
@@ -12,6 +12,24 @@
 extern "C" {
 #endif
 
+#if !__has_include(<metall/logger_interface.h>)
+/// \brief Log message level
+typedef enum metall_log_level {
+    /// \brief Critical logger message
+    metall_critical = 5,
+    /// \brief Error logger message
+    metall_error = 4,
+    /// \brief Warning logger message
+    metall_warning = 3,
+    /// \brief Info logger message
+    metall_info = 2,
+    /// \brief Debug logger message
+    metall_debug = 1,
+    /// \brief Verbose (lowest priority) logger message
+    metall_verbose = 0,
+} metall_log_level;
+#endif
+
 typedef struct metall_manager metall_manager;
 
 /**

--- a/src/dice/ffi/metall_internal.hpp
+++ b/src/dice/ffi/metall_internal.hpp
@@ -24,7 +24,17 @@ namespace dice::metall_ffi::internal {
           template<typename T>
           using allocator_type = typename metall::manager::template allocator_type<T>;
 
-          using metall::manager::manager;
+          metall_manager(metall::create_only_t op, char const *path) : manager_{op, path},
+                                                                       read_only_{false} {
+          }
+
+          metall_manager(metall::open_only_t op, char const *path) : manager_{op, path},
+                                                                     read_only_{false} {
+          }
+
+          metall_manager(metall::open_read_only_t op, char const *path) : manager_{op, path},
+                                                                          read_only_{true} {
+          }
 
           [[nodiscard]] bool read_only() const noexcept {
                return read_only_;

--- a/src/dice/ffi/metall_internal.hpp
+++ b/src/dice/ffi/metall_internal.hpp
@@ -22,6 +22,9 @@ namespace dice::metall_ffi::internal {
           metall::manager manager_;
           bool read_only_;
 
+          template<typename T>
+          using allocator_type = typename metall::manager::template allocator_type<T>;
+
           metall_manager(metall::create_only_t op, char const *path) : manager_{op, path},
                                                                        read_only_{false} {
           }

--- a/src/dice/ffi/metall_internal.hpp
+++ b/src/dice/ffi/metall_internal.hpp
@@ -24,15 +24,15 @@ namespace dice::metall_ffi::internal {
           template<typename T>
           using allocator_type = typename metall::manager::template allocator_type<T>;
 
-          metall_manager(metall::create_only_t op, char const *path) : manager_{op, path},
+          metall_manager(metall::create_only_t op, char const *path) : metall::manager{op, path},
                                                                        read_only_{false} {
           }
 
-          metall_manager(metall::open_only_t op, char const *path) : manager_{op, path},
+          metall_manager(metall::open_only_t op, char const *path) : metall::manager{op, path},
                                                                      read_only_{false} {
           }
 
-          metall_manager(metall::open_read_only_t op, char const *path) : manager_{op, path},
+          metall_manager(metall::open_read_only_t op, char const *path) : metall::manager{op, path},
                                                                           read_only_{true} {
           }
 

--- a/src/dice/ffi/metall_internal.hpp
+++ b/src/dice/ffi/metall_internal.hpp
@@ -5,11 +5,63 @@
 #include <metall/metall.hpp>
 
 namespace dice::metall_ffi::internal {
-    /**
+#if METALL_VERSION >= 2800
+     /**
      * @brief The metall manager type used internally.
      *      This object type is whats actually behind the opaque ::metall_manager * in the interface
      */
-    using metall_manager = metall::manager;
+     using metall_manager = metall::manager;
+#else
+
+     /**
+      * @brief The metall manager type used internally.
+      *      This object type is whats actually behind the opaque ::metall_manager * in the interface.
+      *      This is a wrapper that contains the read_only flag for older versions that do not support read_only() yet.
+      */
+     struct metall_manager {
+          metall::manager manager_;
+          bool read_only_;
+
+          metall_manager(metall::create_only_t op, char const *path) : manager_{op, path},
+                                                                       read_only_{false} {
+          }
+
+          metall_manager(metall::open_only_t op, char const *path) : manager_{op, path},
+                                                                     read_only_{false} {
+          }
+
+          metall_manager(metall::open_read_only_t op, char const *path) : manager_{op, path},
+                                                                          read_only_{true} {
+          }
+
+          bool check_sanity() noexcept {
+               return manager_.check_sanity();
+          }
+
+          bool read_only() const noexcept {
+               return read_only_;
+          }
+
+          bool snapshot(char const *dst) {
+               return manager_.snapshot(dst);
+          }
+
+          template<typename T>
+          auto construct(char const *name) {
+               return manager_.construct<T>(name);
+          }
+
+          template<typename T>
+          auto find(char const *name) {
+               return manager_.find<T>(name);
+          }
+
+          template<typename T>
+          auto destroy(char const *name) {
+               return manager_.destroy<T>(name);
+          }
+     };
+#endif
 } // namespace
 
 #endif//DICE_METALLFFI_METALLINTERNAL_HPP

--- a/src/dice/ffi/metall_internal.hpp
+++ b/src/dice/ffi/metall_internal.hpp
@@ -18,51 +18,13 @@ namespace dice::metall_ffi::internal {
       *      This object type is whats actually behind the opaque ::metall_manager * in the interface.
       *      This is a wrapper that contains the read_only flag for older versions that do not support read_only() yet.
       */
-     struct metall_manager {
-          metall::manager manager_;
+     struct metall_manager : metall::manager {
           bool read_only_;
 
           template<typename T>
           using allocator_type = typename metall::manager::template allocator_type<T>;
 
-          metall_manager(metall::create_only_t op, char const *path) : manager_{op, path},
-                                                                       read_only_{false} {
-          }
-
-          metall_manager(metall::open_only_t op, char const *path) : manager_{op, path},
-                                                                     read_only_{false} {
-          }
-
-          metall_manager(metall::open_read_only_t op, char const *path) : manager_{op, path},
-                                                                          read_only_{true} {
-          }
-
-          bool check_sanity() noexcept {
-               return manager_.check_sanity();
-          }
-
-          bool read_only() const noexcept {
-               return read_only_;
-          }
-
-          bool snapshot(char const *dst) {
-               return manager_.snapshot(dst);
-          }
-
-          template<typename T>
-          auto construct(char const *name) {
-               return manager_.construct<T>(name);
-          }
-
-          template<typename T>
-          auto find(char const *name) {
-               return manager_.find<T>(name);
-          }
-
-          template<typename T>
-          auto destroy(char const *name) {
-               return manager_.destroy<T>(name);
-          }
+          using metall::manager::manager;
      };
 #endif
 } // namespace

--- a/src/dice/ffi/metall_internal.hpp
+++ b/src/dice/ffi/metall_internal.hpp
@@ -25,6 +25,10 @@ namespace dice::metall_ffi::internal {
           using allocator_type = typename metall::manager::template allocator_type<T>;
 
           using metall::manager::manager;
+
+          [[nodiscard]] bool read_only() const noexcept {
+               return read_only_;
+          }
      };
 #endif
 } // namespace

--- a/test_package/example.cpp
+++ b/test_package/example.cpp
@@ -1,8 +1,10 @@
 #include <dice/ffi/metall.h>
 
+#if __has_include(<metall/logger_interface.h>)
 extern "C" void metall_log(metall_log_level, char const *, size_t, char const *) {
 	// noop
 }
+#endif
 
 int main() {
     metall_open("/tmp/test");

--- a/tests/tests_Sanity.cpp
+++ b/tests/tests_Sanity.cpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <random>
 
-#if METALL_VERSION >= 2800
+#if __has_include(<metall/logger_interface.h>)
 extern "C" void metall_log(metall_log_level lvl, char const *file, size_t line, char const *msg) {
     std::cerr << lvl << " " << file << ":" << line << ": " << msg << std::endl;
 }

--- a/tests/tests_Sanity.cpp
+++ b/tests/tests_Sanity.cpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <random>
 
-#if __has_include(<metall/logger_interface.h>)
+#if METALL_VERSION >= 2800
 extern "C" void metall_log(metall_log_level lvl, char const *file, size_t line, char const *msg) {
     std::cerr << lvl << " " << file << ":" << line << ": " << msg << std::endl;
 }

--- a/tests/tests_Sanity.cpp
+++ b/tests/tests_Sanity.cpp
@@ -6,9 +6,11 @@
 #include <string>
 #include <random>
 
+#if __has_include(<metall/logger_interface.h>)
 extern "C" void metall_log(metall_log_level lvl, char const *file, size_t line, char const *msg) {
     std::cerr << lvl << " " << file << ":" << line << ": " << msg << std::endl;
 }
+#endif
 
 TEST_SUITE("metall-ffi") {
     TEST_CASE("sanity check") {


### PR DESCRIPTION
Conditionally include the logger header to provide compat with older metall versions.
This is needed if dependents of this package want to override the metall version