### PR TITLE
Fix: metall compat with boost >= 1.85

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -32,6 +32,7 @@ class Recipe(ConanFile):
 
     def requirements(self):
         self.requires("metall/0.28", transitive_headers=True)
+        self.requires("boost/1.86.0", override=True)
 
         if self.options.with_test_deps:
             self.requires("doctest/2.4.11")

--- a/conanfile.py
+++ b/conanfile.py
@@ -32,7 +32,6 @@ class Recipe(ConanFile):
 
     def requirements(self):
         self.requires("metall/0.28", transitive_headers=True)
-        self.requires("boost/1.86.0", override=True)
 
         if self.options.with_test_deps:
             self.requires("doctest/2.4.11")

--- a/src/dice/ffi/metall_internal.hpp
+++ b/src/dice/ffi/metall_internal.hpp
@@ -1,6 +1,36 @@
 #ifndef DICE_METALLFFI_METALLINTERNAL_HPP
 #define DICE_METALLFFI_METALLINTERNAL_HPP
 
+#include <boost/version.hpp>
+
+#if BOOST_VERSION >= 108500
+#include <boost/interprocess/detail/segment_manager_helper.hpp>
+
+namespace boost::interprocess::ipcdetail {
+     /**
+      * This function was originally in boost, but they removed it in recent release (>=1.85)
+      * Even though this is an implementation detail of boost, metall still relies on it, so
+      * to ensure compatibility with more recent boost releases we have to add it here.
+      * (slightly modified)
+      *
+      * https://github.com/boostorg/interprocess/blob/a0c5a8ff176434c9024d4540ce092a2eebb8c5c3/include/boost/interprocess/detail/segment_manager_helper.hpp#L211-L224
+      */
+     inline void array_construct(void *mem, std::size_t num, in_place_interface &table) {
+          //Try constructors
+          BOOST_TRY{
+               table.construct_n(mem, num);
+          }
+          //If there is an exception call destructors and erase index node
+          BOOST_CATCH(...){
+               table.destroy_n(mem, num);
+               BOOST_RETHROW
+          } BOOST_CATCH_END
+    }
+} // namespace boost::interprocess::ipcdetail
+
+#endif // BOOST_VERSION
+
+
 #define METALL_LOGGER_EXTERN_C 1
 #include <metall/metall.hpp>
 

--- a/src/dice/ffi/metall_internal.hpp
+++ b/src/dice/ffi/metall_internal.hpp
@@ -17,11 +17,11 @@ namespace boost::interprocess::ipcdetail {
       */
      inline void array_construct(void *mem, std::size_t num, in_place_interface &table) {
           //Try constructors
-          BOOST_TRY{
+          BOOST_TRY {
                table.construct_n(mem, num);
           }
           //If there is an exception call destructors and erase index node
-          BOOST_CATCH(...){
+          BOOST_CATCH(...) {
                table.destroy_n(mem, num);
                BOOST_RETHROW
           } BOOST_CATCH_END


### PR DESCRIPTION
Fix compat with recent boost releases.

## Issue
Previously `construct_n` had an additional out parameter that told you how many elements were successfully constructed, this is no longer the case.

Compare the impl in this with the original boost impl:
https://github.com/boostorg/interprocess/blob/a0c5a8ff176434c9024d4540ce092a2eebb8c5c3/include/boost/interprocess/detail/segment_manager_helper.hpp#L211-L224