### PR TITLE
Pin cpp-conan-release-reusable-workflow to v1.0.3

### DIFF
--- a/.github/workflows/publish-conan-branch-package.yml
+++ b/.github/workflows/publish-conan-branch-package.yml
@@ -7,7 +7,7 @@ concurrency:
 
 jobs:
   publish-conan-branch-package:
-    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-conan-branch-package.yml@main
+    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-conan-branch-package.yml@v1.0.3
     with:
       public_artifactory: true
       os: ubuntu-24.04

--- a/.github/workflows/publish-conan-branch-package.yml
+++ b/.github/workflows/publish-conan-branch-package.yml
@@ -13,7 +13,7 @@ jobs:
       os: ubuntu-24.04
       compiler: clang-20
       cmake-version: 3.22.6
-      conan-version: 2.17.0
+      conan-version: 2.21.0
       conan-options: -o boost/*:header_only=True
     secrets:
       CONAN_USER: ${{ secrets.CONAN_USER }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   publish-release:
-    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-release.yml@main
+    uses: dice-group/cpp-conan-release-reusable-workflow/.github/workflows/publish-release.yml@v1.0.3
     with:
       public_artifactory: true
       os: ubuntu-24.04

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,7 +19,7 @@ jobs:
       os: ubuntu-24.04
       compiler: clang-20
       cmake-version: 3.22.6
-      conan-version: 2.17.0
+      conan-version: 2.21.0
       conan-options: -o boost/*:header_only=True
     secrets:
       CONAN_USER: ${{ secrets.CONAN_USER }}

--- a/conanfile.py
+++ b/conanfile.py
@@ -30,6 +30,9 @@ class Recipe(ConanFile):
 
     def requirements(self):
         self.requires("metall/0.32", transitive_headers=True)
+        # metall/0.32 calls boost::interprocess's construct_n() with its pre-1.91 2-arg
+        # signature; boost 1.91 added a SegmentManager* parameter, breaking the build.
+        self.requires("boost/1.90.0", override=True)
 
         if self.options.with_test_deps:
             self.requires("doctest/2.4.11")


### PR DESCRIPTION
Previously referenced @main, so any change to that repo took effect immediately here with no version buffer. Pinning to v1.0.3 removes that coupling.